### PR TITLE
Encoding a frozen proto will raise

### DIFF
--- a/spec/encoding/frozen_spec.rb
+++ b/spec/encoding/frozen_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+require PROTOS_PATH.join('google_unittest.pb')
+
+RSpec.describe ::Protobuf do
+  it "can encode a frozen proto" do
+    message = Protobuf_unittest::TestAllTypes.new.freeze
+    expect(message.to_s).to be an_instance_of(String)
+  end
+end


### PR DESCRIPTION
https://github.com/ruby-protobuf/protobuf/commit/71b2fc09951d042d8d24470de9e3353b94144f22#diff-ef5972b95ab815a1753b6e1677178dac introduced an instance variable. For a frozen proto, setting that instance variable during encoding will raise.

Example stack trace:
```
     FrozenError:
       can't modify frozen Protobuf_unittest::TestAllTypes
     # ./lib/protobuf/message/fields.rb:30:in `_protobuf_message_unset_required_field_tags'
     # ./lib/protobuf/message.rb:73:in `each_field_for_serialization'
     # ./lib/protobuf/encoder.rb:4:in `encode'
     # ./lib/protobuf/message/serialization.rb:60:in `encode_to'
     # ./lib/protobuf/message/serialization.rb:53:in `encode'
```